### PR TITLE
feat: 添加已删除验证器回收站功能

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -14,6 +14,7 @@ export interface OtpItem {
     algorithm?: 'SHA1' | 'SHA256' | 'SHA512';
     type?: 'totp' | 'hotp';
     counter?: number;
+    deletedAt?: string; // ISO string timestamp for when item was deleted
 }
 
 interface ImportTextFileResult {
@@ -54,6 +55,9 @@ declare global {
                 importOtpFromFile: (filePath: string) => ImportTextFileResult;
                 exportOtpToFile: () => ExportResult;
                 generateOtpUri: (item: OtpItem) => string;
+                getDeletedItems: () => OtpItem[];
+                restoreDeletedItem: (id: string) => boolean;
+                permanentDeleteItem: (id: string) => boolean;
             }
         }
         utools?: {


### PR DESCRIPTION
- 修改删除逻辑，将验证器移动到已删除列表而非直接删除
- 在界面底部添加已删除验证器查看图标
- 实现已删除验证器的恢复和永久删除功能
- 添加删除时间戳记录
- 更新TypeScript类型定义

🤖 Generated with [Claude Code](https://claude.ai/code)