### PR TITLE
fix: 修复导出时备注字段换行符导致格式损坏的问题

### DIFF
--- a/plugin/remark_codec.js
+++ b/plugin/remark_codec.js
@@ -1,0 +1,48 @@
+// 备注转义规则
+// - \n 表示换行
+// - \\ 表示字面量反斜杠
+
+function escapeRemark(remark) {
+    if (!remark || typeof remark !== 'string') return remark;
+    // 先转义反斜杠，再转义换行，避免把字面量 \n 误当成换行
+    return remark.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+}
+
+function unescapeRemark(remark) {
+    if (!remark || typeof remark !== 'string') return remark;
+
+    let result = '';
+    for (let i = 0; i < remark.length; i++) {
+        const char = remark[i];
+        if (char !== '\\') {
+            result += char;
+            continue;
+        }
+
+        const next = remark[i + 1];
+        if (next === undefined) {
+            result += '\\';
+            continue;
+        }
+
+        if (next === 'n') {
+            result += '\n';
+            i++;
+            continue;
+        }
+
+        if (next === '\\') {
+            result += '\\';
+            i++;
+            continue;
+        }
+
+        // 未知转义保持原样
+        result += '\\' + next;
+        i++;
+    }
+
+    return result;
+}
+
+module.exports = { escapeRemark, unescapeRemark };

--- a/plugin/remark_codec_selftest.js
+++ b/plugin/remark_codec_selftest.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const { escapeRemark, unescapeRemark } = require('./remark_codec');
+
+function roundTrip(input) {
+  return unescapeRemark(escapeRemark(input));
+}
+
+const cases = [
+  '',
+  'plain',
+  '中文备注',
+  'line1\nline2',
+  'folder\\name', // 字面量 \n
+  'literal \\n',
+  'trailing backslash \\',
+  'mix: \\\\ and \\n and \n',
+  'contains & = % ? #',
+];
+
+for (const input of cases) {
+  const output = roundTrip(input);
+  assert.strictEqual(output, input, `roundtrip failed: ${JSON.stringify({ input, output })}`);
+}
+
+assert.strictEqual(escapeRemark('a\nb'), 'a\\nb');
+assert.strictEqual(unescapeRemark('a\\nb'), 'a\nb');
+assert.strictEqual(unescapeRemark('a\\\\nb'), 'a\\nb');
+
+console.log('OK: remark codec roundtrip');


### PR DESCRIPTION
## 问题描述

导出 OTP 到文本文件时，如果备注字段包含换行符，会导致：
- 导出的 URI 格式被破坏（换行符被当成行分隔符）
- 导出的文件无法正确重新导入

## 解决方案

为备注字段添加编解码功能：
- **编码**：将 `\n` 转义为 `\\n`，`\\` 转义为 `\\\\`
- **解码**：将 `\\n` 还原为换行符，`\\\\` 还原为单个反斜杠

## 主要变更

- **新增 `plugin/remark_codec.js`**：实现备注字段的转义/反转义逻辑
- **新增 `plugin/remark_codec_selftest.js`**：单元测试，覆盖各种边界情况
- **修改 `plugin/preload.js`**：
  - `parseOtpUri`：添加 `unescapeRemark` 解码备注
  - `generateOtpUri`：添加 `escapeRemark` 编码备注
  - 修复导出函数中的 URI 解码逻辑（使用 `decodeURI`）

## 测试计划

- [ ] 运行 `node plugin/remark_codec_selftest.js` 验证编解码逻辑
- [ ] 测试包含换行符的备注导出，确认格式正确
- [ ] 测试导出的文件可以正确重新导入