### PR TITLE
feat: add OTP QR code sharing

### DIFF
--- a/plugin/preload.js
+++ b/plugin/preload.js
@@ -387,7 +387,7 @@ function importOtpFromFile(filePath) {
 }
 
 // 生成OTP URI
-function generateOtpUri(item) {
+function generateOtpUri(item, options = {}) {
     try {
         if (!item.secret) {
             throw new Error('缺少必要的 secret 参数');
@@ -435,7 +435,7 @@ function generateOtpUri(item) {
             params.set('counter', item.counter.toString());
         }
 
-        if (item.remark) {
+        if (options.includeRemark !== false && item.remark) {
             params.set('remark', escapeRemark(item.remark));
         }
         

--- a/plugin/preload.js
+++ b/plugin/preload.js
@@ -435,7 +435,7 @@ function generateOtpUri(item, options = {}) {
             params.set('counter', item.counter.toString());
         }
 
-        if (options.includeRemark !== false && item.remark) {
+        if (options?.includeRemark !== false && item.remark) {
             params.set('remark', escapeRemark(item.remark));
         }
         

--- a/src/components/OtpCard.tsx
+++ b/src/components/OtpCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Card, Progress, Typography, Space, theme, Button, Modal } from 'antd';
-import { DeleteOutlined, EditOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { Alert, Button, Card, Modal, Progress, QRCode, Space, Tooltip, Typography, theme } from 'antd';
+import { DeleteOutlined, EditOutlined, InfoCircleOutlined, ShareAltOutlined } from '@ant-design/icons';
 import { messageRef } from '../App';
 import { OtpItem } from '../custom';
 import { DEFAULT_OTP_PERIOD } from '../constants';
@@ -10,16 +10,7 @@ const { useToken } = theme;
 const REMARK_LEN = 20
 
 interface OtpCardProps {
-  item: {
-    id: string;
-    name: string;
-    secret: string;
-    issuer?: string;
-    remark?: string;
-    digits?: number;
-    period?: number;
-    algorithm?: 'SHA1' | 'SHA256' | 'SHA512';
-  };
+  item: OtpItem;
   index: number;
   onDelete: (id: string) => void;
   onEdit: (item: OtpItem) => void;
@@ -42,6 +33,8 @@ const OtpCard: React.FC<OtpCardProps> = ({
   const [otp, setOtp] = useState('');
   const [nextOtp, setNextOtp] = useState(''); // 新增状态：存储下一个OTP
   const [showRemarkModal, setShowRemarkModal] = useState(false);
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [shareUri, setShareUri] = useState('');
   const period = item.period || DEFAULT_OTP_PERIOD;
   const { token } = useToken();
 
@@ -120,6 +113,24 @@ const OtpCard: React.FC<OtpCardProps> = ({
     }
   }, [nextOtp]);
 
+  const handleShare = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+
+    try {
+      const uri = window.api.otp.generateOtpUri(item, { includeRemark: false });
+      setShareUri(uri);
+      setShowShareModal(true);
+    } catch (error) {
+      console.error('生成分享二维码失败:', error);
+      messageRef.current?.error('生成分享二维码失败');
+    }
+  }, [item]);
+
+  const closeShareModal = useCallback(() => {
+    setShowShareModal(false);
+    setShareUri('');
+  }, []);
+
   // 支持快捷键
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -165,6 +176,14 @@ const OtpCard: React.FC<OtpCardProps> = ({
               onEdit(item);
             }}
           />
+          <Tooltip title="分享密钥">
+            <Button
+              icon={<ShareAltOutlined />}
+              size="small"
+              aria-label="分享密钥"
+              onClick={handleShare}
+            />
+          </Tooltip>
           <Button
             icon={<DeleteOutlined />}
             size="small"
@@ -293,6 +312,38 @@ const OtpCard: React.FC<OtpCardProps> = ({
           </div>
         </Modal>
       )}
+      <Modal
+        title="分享验证器"
+        open={showShareModal}
+        onCancel={(e: React.MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation();
+          closeShareModal();
+        }}
+        footer={null}
+        maskClosable={true}
+      >
+        <div
+          onClick={(e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}
+        >
+          <div style={{ textAlign: 'center' }}>
+            <Text strong style={{ display: 'block' }}>{item.issuer || '未知发行方'}</Text>
+            <Text type="secondary">{item.account || item.name}</Text>
+          </div>
+          {shareUri && (
+            <div style={{ padding: 12, backgroundColor: '#fff', borderRadius: token.borderRadiusLG }}>
+              <QRCode value={shareUri} size={220} bordered={false} errorLevel="M" />
+            </div>
+          )}
+          <Text type="secondary">请使用其他验证器扫描二维码导入</Text>
+          <Alert
+            type="warning"
+            showIcon
+            message="二维码包含登录密钥，请勿截图或发送给不可信的人"
+            style={{ width: '100%' }}
+          />
+        </div>
+      </Modal>
     </Card>
   );
 };

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -90,7 +90,7 @@ declare global {
                 importOtpTextFile: (text: string) => ImportTextFileResult;
                 importOtpFromFile: (filePath: string) => ImportTextFileResult;
                 exportOtpToFile: () => ExportResult;
-                generateOtpUri: (item: OtpItem) => string;
+                generateOtpUri: (item: OtpItem, options?: { includeRemark?: boolean }) => string;
                 getDeletedItems: () => OtpItem[];
                 restoreDeletedItem: (id: string) => boolean;
                 permanentDeleteItem: (id: string) => boolean;


### PR DESCRIPTION
## 变更内容

- 在每个 OTP 卡片的操作区增加“分享密钥”按钮
- 点击后使用 Ant Design QRCode 展示标准 `otpauth://` 二维码
- 二维码保留 issuer、账户、算法、位数、周期和 HOTP counter 等标准参数
- 分享 URI 排除 FastOtp 自定义 remark 参数，但文本导出继续保留备注
- 关闭弹窗时清理内存中的分享 URI，并增加密钥泄露安全提示
- 统一 OtpCard 的 item 类型为完整 OtpItem

## 用户影响

用户可以直接用 Google Authenticator、Microsoft Authenticator、1Password 等兼容验证器扫描二维码导入密钥，无需先导出文本文件。

## 验证

- `npm run lint`：通过，只有项目原有的 App.tsx Fast Refresh warning
- `npm run build`：通过
- `node --check plugin/preload.js`：通过
- `git diff --check`：通过

## 手动验证建议

在 uTools 中打开任意验证器的分享弹窗，分别使用目标验证器扫描普通 TOTP、中文名称以及非默认算法配置的二维码。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Share Secret” action to validator cards.
  * Display sharing details in a modal with a QR code and import instructions.
  * Sharing excludes the validator’s remark by default to help protect sensitive information.
* **Improvements**
  * Added an option to control whether remarks are included when generating sharing links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->