### PR TITLE
feat: add grid view for OTP codes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,36 @@
   padding: 8px 12px;
 }
 
+.otp-cards-container--grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.otp-card-slot {
+  min-width: 0;
+}
+
+.otp-card-title {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.otp-card--grid .otp-card-title .ant-typography {
+  min-width: 0;
+  max-width: 160px;
+}
+
+.otp-card--grid .ant-card-head-title {
+  min-width: 0;
+}
+
+@media (max-width: 719px) {
+  .otp-cards-container--grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 /* 确保底部工具栏在小屏幕上也能正确显示 */
 .otp-footer {
   position: fixed;

--- a/src/App.css
+++ b/src/App.css
@@ -16,7 +16,7 @@
 
 .otp-cards-container--grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
   gap: 10px;
 }
 
@@ -36,12 +36,6 @@
 
 .otp-card--grid .ant-card-head-title {
   min-width: 0;
-}
-
-@media (max-width: 719px) {
-  .otp-cards-container--grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
 }
 
 /* 确保底部工具栏在小屏幕上也能正确显示 */

--- a/src/App.css
+++ b/src/App.css
@@ -29,9 +29,15 @@
   min-width: 0;
 }
 
-.otp-card--grid .otp-card-title .ant-typography {
+.otp-card--grid .otp-card-title .ant-space-item {
   min-width: 0;
-  max-width: 160px;
+  flex-shrink: 1;
+}
+
+.otp-card--grid .otp-card-title .ant-typography {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .otp-card--grid .ant-card-head-title {

--- a/src/components/OtpCard.tsx
+++ b/src/components/OtpCard.tsx
@@ -18,6 +18,7 @@ interface OtpCardProps {
   onOtpGenerated?: (otp: string) => void;
   timeLeft: number; // 从父组件传入的计时器时间
   refreshKey: number; // 用于触发OTP刷新的计数器
+  isGrid?: boolean;
 }
 
 const OtpCard: React.FC<OtpCardProps> = ({ 
@@ -28,7 +29,8 @@ const OtpCard: React.FC<OtpCardProps> = ({
   isSelected = false, 
   onOtpGenerated,
   timeLeft,
-  refreshKey
+  refreshKey,
+  isGrid = false
 }) => {
   const [otp, setOtp] = useState('');
   const [nextOtp, setNextOtp] = useState(''); // 新增状态：存储下一个OTP
@@ -155,11 +157,12 @@ const OtpCard: React.FC<OtpCardProps> = ({
 
   return (
     <Card
+      className={`otp-card${isGrid ? ' otp-card--grid' : ''}`}
       title={
-        <Space>
-          {item.issuer && <Text strong>{item.issuer}</Text>}
-          <Text>{item.name}</Text>
-          {index < 9 && (
+        <Space size={6} className="otp-card-title">
+          {item.issuer && <Text strong ellipsis={isGrid}>{item.issuer}</Text>}
+          <Text ellipsis={isGrid}>{item.name}</Text>
+          {!isGrid && index < 9 && (
             <Text type="secondary" style={{ fontSize: '12px' }}>
               (Ctrl/⌘+{index + 1})
             </Text>
@@ -167,10 +170,12 @@ const OtpCard: React.FC<OtpCardProps> = ({
         </Space>
       }
       extra={
-        <Space>
+        <Space size={isGrid ? 2 : 8}>
           <Button
             icon={<EditOutlined />}
             size="small"
+            type={isGrid ? 'text' : 'default'}
+            aria-label="编辑验证器"
             onClick={(e) => {
               e.stopPropagation(); // 阻止事件冒泡
               onEdit(item);
@@ -180,6 +185,7 @@ const OtpCard: React.FC<OtpCardProps> = ({
             <Button
               icon={<ShareAltOutlined />}
               size="small"
+              type={isGrid ? 'text' : 'default'}
               aria-label="分享密钥"
               onClick={handleShare}
             />
@@ -187,6 +193,8 @@ const OtpCard: React.FC<OtpCardProps> = ({
           <Button
             icon={<DeleteOutlined />}
             size="small"
+            type={isGrid ? 'text' : 'default'}
+            aria-label="删除验证器"
             danger
             onClick={(e) => {
               e.stopPropagation(); // 阻止事件冒泡
@@ -196,9 +204,10 @@ const OtpCard: React.FC<OtpCardProps> = ({
         </Space>
       }
       style={{ 
-        marginBottom: 10,
+        marginBottom: isGrid ? 0 : 10,
         backgroundColor: selectedBgColor,
         width: '100%',
+        height: isGrid ? '100%' : undefined,
         border: isSelected ? `1px solid ${token.colorPrimary}` : undefined,
         cursor: 'pointer', // 添加指针样式表明可点击
       }}
@@ -206,9 +215,9 @@ const OtpCard: React.FC<OtpCardProps> = ({
       styles={{
         body: {
           transition: 'all 0.3s',
-          padding: '8px 16px',
+          padding: isGrid ? '10px 12px' : '8px 16px',
         },
-        header: { padding: '0 16px' },
+        header: { padding: isGrid ? '0 12px' : '0 16px' },
       }}
       onClick={copyCurrentOtp} // 添加点击事件
     >

--- a/src/components/OtpManager.tsx
+++ b/src/components/OtpManager.tsx
@@ -185,7 +185,7 @@ const OtpManager: React.FC = () => {
     // 重置引用数组大小以匹配当前项目数量
     cardRefs.current = cardRefs.current.slice(0, filteredItems.length);
     // 如果有项目且未选择任何项目，默认选择第一个
-    if (filteredItems.length > 0 && selectedIndex === -1) {
+    if (filteredItems.length > 0 && selectedIndex < 0) {
       setSelectedIndex(0);
     } else if (selectedIndex >= filteredItems.length) {
       // 如果选择的索引超出范围，重置为最后一个
@@ -288,6 +288,8 @@ const OtpManager: React.FC = () => {
     }
 
     console.log('键盘事件:', event.key, '当前选中:', selectedIndex);
+
+    if (filteredItems.length === 0 || selectedIndex < 0) return;
 
     const verticalStep = viewMode === 'grid' ? gridColumnCount : 1;
 

--- a/src/components/OtpManager.tsx
+++ b/src/components/OtpManager.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback, useContext } from 'react';
-import { Button, Empty, Modal, Typography, Input, App, Space, Tooltip, theme, List } from 'antd';
-import { PlusOutlined, ExclamationCircleFilled, ImportOutlined, QuestionCircleOutlined, FileTextOutlined, ExportOutlined, HistoryOutlined, DeleteOutlined, UndoOutlined, DeleteFilled, CloudSyncOutlined } from '@ant-design/icons';
+import { Button, Empty, Modal, Typography, Input, App, Space, Tooltip, theme, List, Segmented } from 'antd';
+import { PlusOutlined, ExclamationCircleFilled, ImportOutlined, QuestionCircleOutlined, FileTextOutlined, ExportOutlined, HistoryOutlined, DeleteOutlined, UndoOutlined, DeleteFilled, CloudSyncOutlined, BarsOutlined, AppstoreOutlined } from '@ant-design/icons';
 import OtpCard from './OtpCard';
 import OtpForm from './OtpForm';
 import ChangelogModal from './ChangelogModal';
@@ -16,6 +16,18 @@ import WebDavBackupModal from './WebDavBackupModal';
 const { Text } = Typography;
 const { TextArea } = Input;
 const { useToken } = theme;
+type ViewMode = 'list' | 'grid';
+
+const VIEW_MODE_STORAGE_KEY = 'fastotp:view-mode';
+const GRID_BREAKPOINT = 720;
+
+const getInitialViewMode = (): ViewMode => {
+  try {
+    return window.localStorage.getItem(VIEW_MODE_STORAGE_KEY) === 'grid' ? 'grid' : 'list';
+  } catch {
+    return 'list';
+  }
+};
 
 const calculateTimeLeft = () => {
   const now = Math.floor(Date.now() / 1000);
@@ -35,6 +47,8 @@ const OtpManager: React.FC = () => {
   const [autoBackupStatus, setAutoBackupStatus] = useState({ running: false, scheduled: false });
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const [groupItems, setGroupItems] = useState<OtpItem[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+  const [gridColumnCount, setGridColumnCount] = useState(() => window.innerWidth >= GRID_BREAKPOINT ? 2 : 1);
   
   // 添加共用计时器状态
   const [timeLeft, setTimeLeft] = useState(DEFAULT_OTP_PERIOD);
@@ -62,6 +76,25 @@ const OtpManager: React.FC = () => {
   );
 
   const pageEnter = useContext(PluginEnterContext);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+    } catch (error) {
+      console.warn('保存验证码显示方式失败:', error);
+    }
+  }, [viewMode]);
+
+  useEffect(() => {
+    const updateGridColumnCount = () => {
+      setGridColumnCount(window.innerWidth >= GRID_BREAKPOINT ? 2 : 1);
+    };
+
+    updateGridColumnCount();
+    window.addEventListener('resize', updateGridColumnCount);
+    return () => window.removeEventListener('resize', updateGridColumnCount);
+  }, []);
+
   useEffect(() => {
     const getStatus = window.api?.backup?.getAutoBackupStatus;
     const onStatusChange = window.api?.backup?.onAutoBackupStatusChange;
@@ -237,12 +270,14 @@ const OtpManager: React.FC = () => {
 
     console.log('键盘事件:', event.key, '当前选中:', selectedIndex);
 
+    const verticalStep = viewMode === 'grid' ? gridColumnCount : 1;
+
     switch (event.key) {
       case 'ArrowUp':
         console.log('向上箭头按下');
         event.preventDefault();
         setSelectedIndex(prev => {
-          const newIndex = Math.max(0, prev - 1);
+          const newIndex = Math.max(0, prev - verticalStep);
           console.log('新索引:', newIndex);
           // 在下一个渲染周期滚动到视图
           setTimeout(() => scrollItemIntoView(newIndex), 0);
@@ -253,9 +288,30 @@ const OtpManager: React.FC = () => {
         console.log('向下箭头按下');
         event.preventDefault();
         setSelectedIndex(prev => {
-          const newIndex = Math.min(filteredItems.length - 1, prev + 1);
+          const newIndex = Math.min(filteredItems.length - 1, prev + verticalStep);
           console.log('新索引:', newIndex);
           // 在下一个渲染周期滚动到视图
+          setTimeout(() => scrollItemIntoView(newIndex), 0);
+          return newIndex;
+        });
+        break;
+      case 'ArrowLeft':
+        if (viewMode !== 'grid') break;
+        event.preventDefault();
+        setSelectedIndex(prev => {
+          const newIndex = gridColumnCount > 1 && prev % gridColumnCount !== 0 ? prev - 1 : prev;
+          setTimeout(() => scrollItemIntoView(newIndex), 0);
+          return newIndex;
+        });
+        break;
+      case 'ArrowRight':
+        if (viewMode !== 'grid') break;
+        event.preventDefault();
+        setSelectedIndex(prev => {
+          const hasItemOnRight = gridColumnCount > 1
+            && prev % gridColumnCount < gridColumnCount - 1
+            && prev + 1 < filteredItems.length;
+          const newIndex = hasItemOnRight ? prev + 1 : prev;
           setTimeout(() => scrollItemIntoView(newIndex), 0);
           return newIndex;
         });
@@ -486,10 +542,11 @@ const OtpManager: React.FC = () => {
     }
 
     return (
-      <div className="otp-cards-container" >
+      <div className={`otp-cards-container otp-cards-container--${viewMode}`}>
         {items.map((item, index) => (
           <div 
             key={item.id}
+            className="otp-card-slot"
             ref={(el) => setCardRef(el, index)}
             onClick={() => setSelectedIndex(index)}
           >
@@ -502,6 +559,7 @@ const OtpManager: React.FC = () => {
               onOtpGenerated={(otp) => handleOtpGenerated(otp, index)}
               timeLeft={timeLeft}
               refreshKey={refreshCounter}
+              isGrid={viewMode === 'grid'}
             />
           </div>
         ))}
@@ -514,6 +572,14 @@ const OtpManager: React.FC = () => {
     setGroupItems(newGroupItems);
     setSelectedIndex(-1); // 重置选中项
   }, []);
+
+  const handleViewModeChange = (mode: ViewMode) => {
+    setViewMode(mode);
+    setTimeout(() => {
+      scrollItemIntoView(selectedIndex);
+      containerRef.current?.focus();
+    }, 0);
+  };
 
 
 
@@ -601,6 +667,31 @@ const OtpManager: React.FC = () => {
             </Space>
             
             <Space size={8}>
+              <Segmented
+                aria-label="验证码显示方式"
+                size="small"
+                value={viewMode}
+                onChange={(value) => handleViewModeChange(value as ViewMode)}
+                onKeyDown={(event) => event.stopPropagation()}
+                options={[
+                  {
+                    value: 'list',
+                    label: (
+                      <Tooltip title="列表显示">
+                        <BarsOutlined aria-label="列表显示" />
+                      </Tooltip>
+                    ),
+                  },
+                  {
+                    value: 'grid',
+                    label: (
+                      <Tooltip title="网格显示">
+                        <AppstoreOutlined aria-label="网格显示" />
+                      </Tooltip>
+                    ),
+                  },
+                ]}
+              />
               <Tooltip title="查看已删除的验证器">
                 <Button 
                   type="text" 
@@ -611,7 +702,7 @@ const OtpManager: React.FC = () => {
               </Tooltip>
               
               {otpItems.length > 0 && (
-                <Tooltip title="使用↑↓键选择验证码，回车键复制选中验证码，或按下 Ctrl/⌘ + 数字键(1-9)快速复制对应的验证码">
+                <Tooltip title="使用方向键选择验证码，回车键复制选中验证码，或按下 Ctrl/⌘ + 数字键(1-9)快速复制对应的验证码">
                   <Space size={4}>
                     <Text type="secondary" style={{ fontSize: '12px' }}>快捷键</Text>
                     <QuestionCircleOutlined style={{ color: token.colorPrimary, fontSize: '14px' }} />

--- a/src/components/OtpManager.tsx
+++ b/src/components/OtpManager.tsx
@@ -19,7 +19,6 @@ const { useToken } = theme;
 type ViewMode = 'list' | 'grid';
 
 const VIEW_MODE_STORAGE_KEY = 'fastotp:view-mode';
-const GRID_BREAKPOINT = 720;
 
 const getInitialViewMode = (): ViewMode => {
   try {
@@ -48,7 +47,7 @@ const OtpManager: React.FC = () => {
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const [groupItems, setGroupItems] = useState<OtpItem[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
-  const [gridColumnCount, setGridColumnCount] = useState(() => window.innerWidth >= GRID_BREAKPOINT ? 2 : 1);
+  const [gridColumnCount, setGridColumnCount] = useState(1);
   
   // 添加共用计时器状态
   const [timeLeft, setTimeLeft] = useState(DEFAULT_OTP_PERIOD);
@@ -64,6 +63,7 @@ const OtpManager: React.FC = () => {
   
   const cardRefs = useRef<HTMLDivElement[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
+  const cardsContainerRef = useRef<HTMLDivElement>(null);
 
   // 获取主题色
   const { token } = useToken();
@@ -84,16 +84,6 @@ const OtpManager: React.FC = () => {
       console.warn('保存验证码显示方式失败:', error);
     }
   }, [viewMode]);
-
-  useEffect(() => {
-    const updateGridColumnCount = () => {
-      setGridColumnCount(window.innerWidth >= GRID_BREAKPOINT ? 2 : 1);
-    };
-
-    updateGridColumnCount();
-    window.addEventListener('resize', updateGridColumnCount);
-    return () => window.removeEventListener('resize', updateGridColumnCount);
-  }, []);
 
   useEffect(() => {
     const getStatus = window.api?.backup?.getAutoBackupStatus;
@@ -119,6 +109,35 @@ const OtpManager: React.FC = () => {
       return groupItems;
     }
   }, [otpItems, searchText, groupItems]);
+
+  useEffect(() => {
+    if (viewMode !== 'grid' || !cardsContainerRef.current) {
+      setGridColumnCount(1);
+      return;
+    }
+
+    const gridElement = cardsContainerRef.current;
+    let frameId = 0;
+    const updateGridColumnCount = () => {
+      cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(() => {
+        const templateColumns = window.getComputedStyle(gridElement).gridTemplateColumns;
+        const columnCount = templateColumns === 'none'
+          ? 1
+          : templateColumns.split(' ').filter(Boolean).length;
+        setGridColumnCount(Math.max(1, columnCount));
+      });
+    };
+
+    updateGridColumnCount();
+    const resizeObserver = new ResizeObserver(updateGridColumnCount);
+    resizeObserver.observe(gridElement);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
+    };
+  }, [viewMode, filteredItems.length]);
 
   // 共用的计时器逻辑
   useEffect(() => {
@@ -542,7 +561,10 @@ const OtpManager: React.FC = () => {
     }
 
     return (
-      <div className={`otp-cards-container otp-cards-container--${viewMode}`}>
+      <div
+        ref={cardsContainerRef}
+        className={`otp-cards-container otp-cards-container--${viewMode}`}
+      >
         {items.map((item, index) => (
           <div 
             key={item.id}


### PR DESCRIPTION
## 变更内容

- 在底部工具栏增加列表 / 网格显示切换
- 网格卡片保持合理最小宽度，根据窗口宽度自动显示尽可能多的列
- 窄窗口自动退化为单列，不产生横向溢出
- 记住用户上次选择的显示方式
- 根据实际列数支持上下左右方向键选择验证码
- 优化网格卡片的标题截断、按钮间距和等高布局

## 用户影响

验证码较多时可以用更紧凑的响应式网格一次查看更多内容；扩大窗口会自动增加列数，同时保留点击复制、编辑、分享、删除和快捷键操作。

## 验证

- `npm run build`
- `npm run lint`（通过；保留 `src/App.tsx` 现有的 Fast Refresh warning）
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added list and grid display modes for OTP cards.
  * Your selected display mode is remembered between sessions.
  * Added responsive grid layouts that adapt to screen size.
  * Added keyboard navigation optimized for grid layouts, including horizontal movement.
  * Improved card spacing, sizing, title handling, and action controls in grid view.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->