### PR TITLE
feat: support importing OTP from QR images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "antd": "^5.24.7",
+        "jsqr": "^1.4.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -2577,6 +2578,12 @@
       "dependencies": {
         "string-convert": "^0.2.0"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "antd": "^5.24.7",
+    "jsqr": "^1.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -7,6 +7,16 @@
       "code": "otp",
       "explain": "OTP 二次验证码，支持快捷键复制",
       "cmds": ["OTP", "二次验证", "验证码", "2FA", "Two-Factor Authentication"]
+    },
+    {
+      "code": "otp-import-image",
+      "explain": "识别图片二维码并导入 OTP",
+      "cmds": [
+        {
+          "type": "img",
+          "label": "导入 OTP 二维码"
+        }
+      ]
     }
   ],
   "development": {

--- a/plugin/preload.js
+++ b/plugin/preload.js
@@ -4,6 +4,7 @@ const otpCode = require('./otp_code');
 const webdavBackup = require('./webdav_backup');
 const { createAutoBackupManager } = require('./auto_backup');
 const fs = require('fs');
+const path = require('path');
 const { escapeRemark, unescapeRemark } = require('./remark_codec');
 
 const DB_KEY_OTP_ITEMS = 'otp_items';
@@ -53,6 +54,7 @@ window.api = {
         importOtpUri,
         importOtpTextFile,
         importOtpFromFile,
+        selectQrImage,
         exportOtpToFile,
         generateOtpUri,
         getDeletedItems,
@@ -383,6 +385,59 @@ function importOtpFromFile(filePath) {
     } catch (error) {
         console.error('从文件导入OTP失败:', error);
         throw error;
+    }
+}
+
+// 选择二维码图片，并转换为渲染层可直接解析的 Data URL
+function selectQrImage() {
+    try {
+        const files = utools.showOpenDialog({
+            title: '选择 OTP 二维码图片',
+            filters: [
+                { name: '图片文件', extensions: ['png', 'jpg', 'jpeg', 'webp', 'bmp', 'gif'] }
+            ],
+            properties: ['openFile']
+        });
+
+        if (!files || files.length === 0) {
+            return null;
+        }
+
+        const filePath = files[0];
+        if (!fs.existsSync(filePath)) {
+            throw new Error('图片文件不存在');
+        }
+
+        const stat = fs.statSync(filePath);
+        if (!stat.isFile()) {
+            throw new Error('请选择图片文件');
+        }
+        if (stat.size > 30 * 1024 * 1024) {
+            throw new Error('图片不能超过 30 MB');
+        }
+
+        const extension = path.extname(filePath).slice(1).toLowerCase();
+        const mimeTypes = {
+            png: 'image/png',
+            jpg: 'image/jpeg',
+            jpeg: 'image/jpeg',
+            webp: 'image/webp',
+            bmp: 'image/bmp',
+            gif: 'image/gif'
+        };
+        const mimeType = mimeTypes[extension];
+        if (!mimeType) {
+            throw new Error('不支持的图片格式');
+        }
+
+        const data = fs.readFileSync(filePath).toString('base64');
+        return {
+            name: path.basename(filePath),
+            dataUrl: `data:${mimeType};base64,${data}`
+        };
+    } catch (error) {
+        console.error('选择二维码图片失败:', error);
+        throw new Error(error?.message || '选择二维码图片失败');
     }
 }
 

--- a/plugin/preload.js
+++ b/plugin/preload.js
@@ -412,8 +412,8 @@ function selectQrImage() {
         if (!stat.isFile()) {
             throw new Error('请选择图片文件');
         }
-        if (stat.size > 30 * 1024 * 1024) {
-            throw new Error('图片不能超过 30 MB');
+        if (stat.size > 10 * 1024 * 1024) {
+            throw new Error('图片不能超过 10 MB');
         }
 
         const extension = path.extname(filePath).slice(1).toLowerCase();

--- a/src/components/OtpForm.tsx
+++ b/src/components/OtpForm.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect } from 'react';
 import { Modal, Form, Input, Button } from 'antd';
 import { DEFAULT_OTP_PERIOD, DEFAULT_OTP_DIGITS, DEFAULT_OTP_ALGORITHM, DEFAULT_OTP_TYPE } from '../constants';
-import { OtpItem } from '../custom';
+import { OtpDraft, OtpItem } from '../custom';
 
 interface OtpFormProps {
   visible: boolean;
   onClose: () => void;
-  onSave: (values: OtpItem) => void;
+  onSave: (values: OtpItem | OtpDraft) => void;
   editItem?: OtpItem | null;
+  initialItem?: OtpDraft | null;
 }
 
 interface OtpFormValues {
@@ -16,13 +17,13 @@ interface OtpFormValues {
   issuer?: string;
   secret: string;
   remark?: string;
-  type: 'totp';
-  algorithm: 'SHA1';
-  digits: 6;
-  period: 30;
+  type: 'totp' | 'hotp';
+  algorithm: 'SHA1' | 'SHA256' | 'SHA512';
+  digits: number;
+  period: number;
 }
 
-const OtpForm: React.FC<OtpFormProps> = ({ visible, onClose, onSave, editItem }) => {
+const OtpForm: React.FC<OtpFormProps> = ({ visible, onClose, onSave, editItem, initialItem }) => {
   const [form] = Form.useForm<OtpFormValues>();
 
   // 处理表单关闭
@@ -32,8 +33,9 @@ const OtpForm: React.FC<OtpFormProps> = ({ visible, onClose, onSave, editItem })
   };
 
   useEffect(() => {
-    if (visible && editItem) {
-      form.setFieldsValue(editItem as OtpFormValues);
+    if (visible && (editItem || initialItem)) {
+      form.resetFields();
+      form.setFieldsValue((editItem || initialItem) as OtpFormValues);
     } else if (visible) {
       form.resetFields();
       // 设置默认值
@@ -44,18 +46,16 @@ const OtpForm: React.FC<OtpFormProps> = ({ visible, onClose, onSave, editItem })
         period: DEFAULT_OTP_PERIOD
       });
     }
-  }, [visible, editItem, form]);
+  }, [visible, editItem, initialItem, form]);
 
   const handleSubmit = () => {
     form.validateFields().then(values => {
-      // 强制设置固定值
-      values.type = DEFAULT_OTP_TYPE;
-      values.algorithm = DEFAULT_OTP_ALGORITHM;
-      values.digits = DEFAULT_OTP_DIGITS;
-      values.period = DEFAULT_OTP_PERIOD;
-      
-      const item = editItem ? { ...editItem, ...values } : values;
-      onSave(item as OtpItem);
+      const item = editItem
+        ? { ...editItem, ...values }
+        : initialItem
+          ? { ...initialItem, ...values }
+          : values;
+      onSave(item as OtpItem | OtpDraft);
       form.resetFields();
     });
   };

--- a/src/components/OtpManager.tsx
+++ b/src/components/OtpManager.tsx
@@ -898,3 +898,57 @@ const OtpManager: React.FC = () => {
             />
           ) : (
             <List
+              dataSource={deletedItems}
+              renderItem={(item) => (
+                <List.Item
+                  actions={[
+                    <Tooltip title="恢复验证器">
+                      <Button
+                        type="text"
+                        icon={<UndoOutlined />}
+                        onClick={() => handleRestoreItem(item.id)}
+                        size="small"
+                      />
+                    </Tooltip>,
+                    <Tooltip title="永久删除">
+                      <Button
+                        type="text"
+                        icon={<DeleteFilled />}
+                        onClick={() => handlePermanentDelete(item.id)}
+                        size="small"
+                        danger
+                      />
+                    </Tooltip>
+                  ]}
+                >
+                  <List.Item.Meta
+                    title={
+                      <div>
+                        <Text strong>{item.issuer || '未知发行方'}</Text>
+                        {item.name && <Text type="secondary" style={{ marginLeft: 8 }}>- {item.name}</Text>}
+                      </div>
+                    }
+                    description={
+                      <div>
+                        {item.remark && (
+                          <div style={{ marginBottom: 4 }}>
+                            <Text type="secondary">{item.remark}</Text>
+                          </div>
+                        )}
+                        <Text type="secondary" style={{ fontSize: '12px' }}>
+                          删除时间: {item.deletedAt ? new Date(item.deletedAt).toLocaleString('zh-CN') : '未知'}
+                        </Text>
+                      </div>
+                    }
+                  />
+                </List.Item>
+              )}
+            />
+          )}
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default OtpManager; 

--- a/src/components/OtpManager.tsx
+++ b/src/components/OtpManager.tsx
@@ -6,7 +6,7 @@ import OtpForm from './OtpForm';
 import ChangelogModal from './ChangelogModal';
 import { messageRef } from '../App';
 import { DEFAULT_OTP_PERIOD } from '../constants';
-import { OtpItem } from '../custom';
+import { OtpDraft, OtpItem } from '../custom';
 import { useSubInput } from '../hooks/useSubInput';
 import PageLayout from './PageLayout';
 import OtpGroup from './OtpGroup';
@@ -27,6 +27,7 @@ const OtpManager: React.FC = () => {
   const [otpItems, setOtpItems] = useState<OtpItem[]>([]);
   const [formVisible, setFormVisible] = useState(false);
   const [editItem, setEditItem] = useState<OtpItem | null>(null);
+  const [initialItem, setInitialItem] = useState<OtpDraft | null>(null);
   const [importModalVisible, setImportModalVisible] = useState(false);
   const [importUri, setImportUri] = useState('');
   const [changelogVisible, setChangelogVisible] = useState(false);
@@ -298,17 +299,19 @@ const OtpManager: React.FC = () => {
 
   const handleAdd = () => {
     setEditItem(null);
+    setInitialItem(null);
     setFormVisible(true);
   };
 
   const handleEdit = (item: OtpItem) => {
     setEditItem(item);
+    setInitialItem(null);
     setFormVisible(true);
   };
 
-  const handleSave = (item: OtpItem) => {
+  const handleSave = (item: OtpItem | OtpDraft) => {
     try {
-      if (item.id) {
+      if ('id' in item && item.id) {
         // 更新现有项目
         window.api.otp.updateOtpItem(item);
         if (messageRef.current) {
@@ -322,6 +325,8 @@ const OtpManager: React.FC = () => {
         }
       }
       setFormVisible(false);
+      setEditItem(null);
+      setInitialItem(null);
       loadOtpItems();
       // 保存后恢复容器焦点
       setTimeout(() => {
@@ -401,16 +406,18 @@ const OtpManager: React.FC = () => {
     setQrImporting(true);
     try {
       const otpUri = await decodeOtpUriFromQrImage(source);
-      window.api.otp.importOtpUri(otpUri);
-      messageRef.current?.success(`${sourceLabel}识别成功，验证器已导入`);
-      loadOtpItems();
+      const parsedItem = window.api.otp.parseOtpUri(otpUri);
+      setEditItem(null);
+      setInitialItem(parsedItem);
+      setFormVisible(true);
+      messageRef.current?.success(`${sourceLabel}识别成功，请确认信息后保存`);
     } catch (error: unknown) {
       console.error('导入OTP二维码失败:', error);
       messageRef.current?.error('导入失败: ' + ((error as Error).message || '未知错误'));
     } finally {
       setQrImporting(false);
     }
-  }, [loadOtpItems]);
+  }, []);
 
   const handleQrFileImport = () => {
     try {
@@ -687,6 +694,8 @@ const OtpManager: React.FC = () => {
         visible={formVisible}
         onClose={() => {
           setFormVisible(false);
+          setEditItem(null);
+          setInitialItem(null);
           // 表单关闭后，恢复容器焦点
           setTimeout(() => {
             if (containerRef.current) {
@@ -696,6 +705,7 @@ const OtpManager: React.FC = () => {
         }}
         onSave={handleSave}
         editItem={editItem}
+        initialItem={initialItem}
       />
 
       <Modal

--- a/src/components/OtpManager.tsx
+++ b/src/components/OtpManager.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback, useContext } from 'react';
 import { Button, Empty, Modal, Typography, Input, App, Space, Tooltip, theme, List } from 'antd';
-import { PlusOutlined, ExclamationCircleFilled, ImportOutlined, QuestionCircleOutlined, FileTextOutlined, ExportOutlined, HistoryOutlined, DeleteOutlined, UndoOutlined, DeleteFilled, CloudSyncOutlined } from '@ant-design/icons';
+import { PlusOutlined, ExclamationCircleFilled, ImportOutlined, QuestionCircleOutlined, FileTextOutlined, ExportOutlined, HistoryOutlined, DeleteOutlined, UndoOutlined, DeleteFilled, CloudSyncOutlined, PictureOutlined } from '@ant-design/icons';
 import OtpCard from './OtpCard';
 import OtpForm from './OtpForm';
 import ChangelogModal from './ChangelogModal';
@@ -12,6 +12,7 @@ import PageLayout from './PageLayout';
 import OtpGroup from './OtpGroup';
 import { PluginEnterContext } from '../hooks/PageEnterContext';
 import WebDavBackupModal from './WebDavBackupModal';
+import { decodeOtpUriFromQrImage, getQrImageSource } from '../utils/qrCode';
 
 const { Text } = Typography;
 const { TextArea } = Input;
@@ -32,6 +33,7 @@ const OtpManager: React.FC = () => {
   const [deletedModalVisible, setDeletedModalVisible] = useState(false);
   const [deletedItems, setDeletedItems] = useState<OtpItem[]>([]);
   const [webdavBackupVisible, setWebdavBackupVisible] = useState(false);
+  const [qrImporting, setQrImporting] = useState(false);
   const [autoBackupStatus, setAutoBackupStatus] = useState({ running: false, scheduled: false });
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const [groupItems, setGroupItems] = useState<OtpItem[]>([]);
@@ -44,6 +46,7 @@ const OtpManager: React.FC = () => {
   
   // 使用useRef代替useState存储验证码，避免重新渲染循环
   const currentOtpsRef = useRef<string[]>([]);
+  const handledQrPayloadRef = useRef<unknown>(undefined);
   
   // 获取App上下文中的modal API
   const { modal } = App.useApp();
@@ -151,7 +154,7 @@ const OtpManager: React.FC = () => {
     }
   };
 
-  const loadOtpItems = () => {
+  const loadOtpItems = useCallback(() => {
     try {
       const items = window.api.otp.getOtpItems();
       setOtpItems(items);
@@ -161,7 +164,7 @@ const OtpManager: React.FC = () => {
         messageRef.current.error('加载验证器列表失败');
       }
     }
-  };
+  }, []);
 
   const loadDeletedItems = () => {
     try {
@@ -222,7 +225,7 @@ const OtpManager: React.FC = () => {
   };
   useEffect(() => {
     loadOtpItems();
-  }, []);
+  }, [loadOtpItems]);
 
   // 使用React的onKeyDown事件处理键盘输入
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -393,6 +396,50 @@ const OtpManager: React.FC = () => {
       }
     }
   };
+
+  const handleQrImageImport = useCallback(async (source: string, sourceLabel: string) => {
+    setQrImporting(true);
+    try {
+      const otpUri = await decodeOtpUriFromQrImage(source);
+      window.api.otp.importOtpUri(otpUri);
+      messageRef.current?.success(`${sourceLabel}识别成功，验证器已导入`);
+      loadOtpItems();
+    } catch (error: unknown) {
+      console.error('导入OTP二维码失败:', error);
+      messageRef.current?.error('导入失败: ' + ((error as Error).message || '未知错误'));
+    } finally {
+      setQrImporting(false);
+    }
+  }, [loadOtpItems]);
+
+  const handleQrFileImport = () => {
+    try {
+      const image = window.api.otp.selectQrImage();
+      if (!image) return;
+      void handleQrImageImport(image.dataUrl, '图片二维码');
+    } catch (error: unknown) {
+      console.error('选择OTP二维码图片失败:', error);
+      messageRef.current?.error('选择图片失败: ' + ((error as Error).message || '未知错误'));
+    }
+  };
+
+  useEffect(() => {
+    if (!pageEnter) {
+      handledQrPayloadRef.current = undefined;
+      return;
+    }
+    if (pageEnter.code !== 'otp-import-image' || pageEnter.type !== 'img') return;
+    if (handledQrPayloadRef.current === pageEnter.payload) return;
+
+    handledQrPayloadRef.current = pageEnter.payload;
+    try {
+      const source = getQrImageSource(pageEnter.payload);
+      void handleQrImageImport(source, '剪贴板二维码');
+    } catch (error: unknown) {
+      console.error('读取uTools剪贴板图片失败:', error);
+      messageRef.current?.error('导入失败: ' + ((error as Error).message || '未知错误'));
+    }
+  }, [pageEnter, handleQrImageImport]);
 
   // 简化文件导入处理，直接使用uTools API选择文件
   const handleFileImport = () => {
@@ -571,6 +618,15 @@ const OtpManager: React.FC = () => {
                   icon={<FileTextOutlined />} 
                   onClick={handleFileImport}
                   size="small"
+                />
+              </Tooltip>
+              <Tooltip title="从二维码图片导入">
+                <Button
+                  type="text"
+                  icon={<PictureOutlined />}
+                  onClick={handleQrFileImport}
+                  size="small"
+                  loading={qrImporting}
                 />
               </Tooltip>
               <Tooltip title="导出验证器配置">

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -59,6 +59,11 @@ interface ImportTextFileResult {
     errors: string[];
 }
 
+interface QrImageSelection {
+    name: string;
+    dataUrl: string;
+}
+
 interface ExportResult {
     success: boolean;
     message: string;
@@ -89,6 +94,7 @@ declare global {
                 importOtpUri: (uri: string) => OtpItem;
                 importOtpTextFile: (text: string) => ImportTextFileResult;
                 importOtpFromFile: (filePath: string) => ImportTextFileResult;
+                selectQrImage: () => QrImageSelection | null;
                 exportOtpToFile: () => ExportResult;
                 generateOtpUri: (item: OtpItem, options?: { includeRemark?: boolean }) => string;
                 getDeletedItems: () => OtpItem[];

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -17,6 +17,8 @@ export interface OtpItem {
     deletedAt?: string; // ISO string timestamp for when item was deleted
 }
 
+export type OtpDraft = Omit<OtpItem, 'id'>;
+
 export interface WebdavBackupConfig {
     dirUrl: string;
     username?: string;
@@ -86,11 +88,11 @@ declare global {
                     algorithm?: 'SHA1' | 'SHA256' | 'SHA512'
                 }) => string;
                 getOtpItems: () => OtpItem[];
-                saveOtpItem: (item: OtpItem) => OtpItem;
+                saveOtpItem: (item: OtpItem | OtpDraft) => OtpItem;
                 deleteOtpItem: (id: string) => void;
                 updateOtpItem: (item: OtpItem) => void;
                 copyToClipboard: (text: string) => void;
-                parseOtpUri: (uri: string) => OtpItem;
+                parseOtpUri: (uri: string) => OtpDraft;
                 importOtpUri: (uri: string) => OtpItem;
                 importOtpTextFile: (text: string) => ImportTextFileResult;
                 importOtpFromFile: (filePath: string) => ImportTextFileResult;

--- a/src/utils/qrCode.ts
+++ b/src/utils/qrCode.ts
@@ -32,8 +32,9 @@ export const getQrImageSource = (payload: unknown): string => {
   }
 
   // 兼容部分 uTools 版本直接传入不带 Data URL 头的 base64 数据。
-  if (/^[A-Za-z0-9+/=\r\n]+$/.test(value) && value.length > 100) {
-    return `data:image/png;base64,${value.replace(/\s/g, '')}`;
+  const cleanValue = value.replace(/\s/g, '');
+  if (/^[A-Za-z0-9+/=]+$/.test(cleanValue) && cleanValue.length > 100) {
+    return `data:image/png;base64,${cleanValue}`;
   }
 
   throw new Error('剪贴板中的内容不是有效图片');

--- a/src/utils/qrCode.ts
+++ b/src/utils/qrCode.ts
@@ -1,0 +1,79 @@
+import jsQR from 'jsqr';
+
+const MAX_IMAGE_SIDE = 3000;
+const SUPPORTED_IMAGE_DATA_URL = /^data:image\/(?:png|jpe?g|webp|bmp|gif);base64,/i;
+
+const loadImage = (source: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('图片读取失败，请选择 PNG、JPG、JPEG、WebP、BMP 或 GIF 图片'));
+    image.src = source;
+  });
+
+export const getQrImageSource = (payload: unknown): string => {
+  const source = typeof payload === 'string'
+    ? payload
+    : payload && typeof payload === 'object' && 'data' in payload
+      ? (payload as { data?: unknown }).data
+      : undefined;
+
+  if (typeof source !== 'string' || !source.trim()) {
+    throw new Error('没有读取到剪贴板图片');
+  }
+
+  const value = source.trim();
+  if (SUPPORTED_IMAGE_DATA_URL.test(value)) {
+    return value;
+  }
+
+  if (value.startsWith('data:image/')) {
+    throw new Error('不支持的剪贴板图片格式');
+  }
+
+  // 兼容部分 uTools 版本直接传入不带 Data URL 头的 base64 数据。
+  if (/^[A-Za-z0-9+/=\r\n]+$/.test(value) && value.length > 100) {
+    return `data:image/png;base64,${value.replace(/\s/g, '')}`;
+  }
+
+  throw new Error('剪贴板中的内容不是有效图片');
+};
+
+export const decodeOtpUriFromQrImage = async (source: string): Promise<string> => {
+  const image = await loadImage(source);
+  const naturalWidth = image.naturalWidth || image.width;
+  const naturalHeight = image.naturalHeight || image.height;
+
+  if (!naturalWidth || !naturalHeight) {
+    throw new Error('图片尺寸无效');
+  }
+
+  const scale = Math.min(1, MAX_IMAGE_SIDE / Math.max(naturalWidth, naturalHeight));
+  const width = Math.max(1, Math.round(naturalWidth * scale));
+  const height = Math.max(1, Math.round(naturalHeight * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) {
+    throw new Error('当前环境不支持图片解析');
+  }
+
+  context.drawImage(image, 0, 0, width, height);
+  const imageData = context.getImageData(0, 0, width, height);
+  const result = jsQR(imageData.data, width, height, {
+    inversionAttempts: 'attemptBoth',
+  });
+
+  if (!result?.data) {
+    throw new Error('图片中未识别到二维码');
+  }
+
+  const value = result.data.trim();
+  if (!value.toLowerCase().startsWith('otpauth://')) {
+    throw new Error('识别到的二维码不是 OTP 验证器二维码');
+  }
+
+  return value;
+};


### PR DESCRIPTION
## 变更内容

- 新增本地二维码图片选择入口，支持 PNG、JPG、JPEG、WebP、BMP 和 GIF
- 新增 uTools `img` 匹配指令，粘贴剪贴板图片后可直接选择“导入 OTP 二维码”
- 使用 `jsQR` 在本地解析二维码，并复用现有 `otpauth://` 解析逻辑
- 识别成功后预填“添加新验证器”表单，用户确认并点击保存后才写入存储和触发自动备份
- 保留二维码中的 OTP 类型、算法、位数、周期及 HOTP counter 等非默认参数
- 对无二维码、非 OTP 二维码、不支持格式和超大图片提供明确错误提示

## 影响

用户可以从网站截图、二维码图片文件或 uTools 剪贴板图片读取单个 OTP 验证器，并在保存前检查或修改发行方、账户和密钥等信息；图片解析完全在本地完成。

## 验证

- `npm run lint`（通过；保留仓库原有的 `src/App.tsx` Fast Refresh warning）
- `npm run build`
- `node --check plugin/preload.js`
- 使用标准 `otpauth://totp/...` 生成二维码并通过 `jsQR` 解码验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to import OTP accounts by scanning QR codes from image files.
  - Supports QR images supplied through plugin navigation.
  - Added image validation and clear error handling for unsupported or invalid files.
  - OTP forms can now be prefilled with imported account details before saving.
- **Improvements**
  - Improved OTP form handling for both new and existing account entries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->