### PR TITLE
feat: add zTools compatibility

### DIFF
--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,4 +1,6 @@
 {
+  "name": "FastOTP",
+  "version": "1.6.0",
   "main": "dist/index.html",
   "logo": "logo.png",
   "preload": "preload.js",

--- a/plugin/preload.js
+++ b/plugin/preload.js
@@ -1,5 +1,11 @@
 console.log("preload.js loaded")
 
+// zTools exposes its uTools-compatible API as `ztools`. Normalize the global
+// before any preload initialization reads `utools`.
+if (!globalThis.utools && globalThis.ztools) {
+    globalThis.utools = globalThis.ztools;
+}
+
 const otpCode = require('./otp_code');
 const webdavBackup = require('./webdav_backup');
 const { createAutoBackupManager } = require('./auto_backup');

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,0 +1,7 @@
+// zTools exposes the uTools-compatible API as `ztools`.
+// Normalize it before any application module is evaluated.
+const pluginWindow = window as typeof window & { ztools?: typeof window.utools }
+
+if (!pluginWindow.utools && pluginWindow.ztools) {
+  pluginWindow.utools = pluginWindow.ztools
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,9 @@
+import './compat'
 import '@ant-design/v5-patch-for-react-19';
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 // import './index.css'
 import App from './App.tsx'
-
-// zTools exposes the uTools-compatible API as `ztools`.
-// Keep the rest of the renderer platform-agnostic by normalizing it once at startup.
-const pluginWindow = window as typeof window & { ztools?: typeof window.utools }
-if (!pluginWindow.utools && pluginWindow.ztools) {
-  pluginWindow.utools = pluginWindow.ztools
-}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,13 @@ import { createRoot } from 'react-dom/client'
 // import './index.css'
 import App from './App.tsx'
 
+// zTools exposes the uTools-compatible API as `ztools`.
+// Keep the rest of the renderer platform-agnostic by normalizing it once at startup.
+const pluginWindow = window as typeof window & { ztools?: typeof window.utools }
+if (!pluginWindow.utools && pluginWindow.ztools) {
+  pluginWindow.utools = pluginWindow.ztools
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## 变更内容

- 在 React 入口启动时将 zTools 的全局 `ztools` API 归一化为现有代码使用的 `utools`
- 在 `preload.js` 初始化最前面执行同样的兼容处理，避免数据库与存储初始化时出现 `utools is not defined`
- 原生 uTools 环境仍优先使用已有的 `utools`，行为不变

## 原因

zTools 暴露的是全局 `ztools` 对象，而 FastOtp 的渲染层和 preload 都直接依赖 `utools`。只在渲染层设置别名无法覆盖 preload 的早期初始化。

## 验证

- `npm run build`：通过（TypeScript + Vite production build）
- `npm run lint`：未执行到代码规则检查；临时验证环境安装依赖时缺少 ESLint 自身的 `@eslint/config-array` 文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility in environments that expose a `zTools` API instead of `uTools`.
  * Automatically maps `zTools` to the expected `uTools` interface when `uTools` is missing.
  * Ensures the compatibility layer initializes early so the app and plugins start consistently.
* **Release**
  * Updated the plugin metadata to name **FastOTP** and version **1.6.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->